### PR TITLE
Fix mobile detection hook for older browsers

### DIFF
--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -10,9 +10,25 @@ export function useIsMobile() {
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
+
+    const supportsEventListener = typeof mql.addEventListener === "function";
+
+    if (supportsEventListener) {
+      mql.addEventListener("change", onChange);
+    } else if (typeof mql.addListener === "function") {
+      // Safari < 14 doesn't support addEventListener on MediaQueryList
+      mql.addListener(onChange);
+    }
+
+    onChange();
+
+    return () => {
+      if (supportsEventListener) {
+        mql.removeEventListener("change", onChange);
+      } else if (typeof mql.removeListener === "function") {
+        mql.removeListener(onChange);
+      }
+    };
   }, []);
 
   return !!isMobile;


### PR DESCRIPTION
## Summary
- add a Safari-compatible fallback in the `useIsMobile` hook so the site no longer crashes when `MediaQueryList.addEventListener` is unavailable
- keep the hook updating its state immediately after mounting to ensure responsive layouts render correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2d1456b48832e9821a34bb401bd6d